### PR TITLE
Fix incorrect checking of SOP marker segment

### DIFF
--- a/source/Tier2/read_packet.m
+++ b/source/Tier2/read_packet.m
@@ -13,10 +13,15 @@ Nsop = -1;
 % if SOP present
 if codingStyle.is_use_SOP() == true
     WORD = hDsrc.get_word();
-    assert(WORD == x_FF91);
-    Lsop = hDsrc.get_word();
-    assert(Lsop == 4);
-    Nsop = hDsrc.get_word();
+    if WORD == x_FF91
+        Lsop = hDsrc.get_word();
+        assert(Lsop == 4);
+        Nsop = hDsrc.get_word();
+    else
+        % SOP may not be present even SPcod says SOP was used
+        hDsrc.pos = hDsrc.pos - 2; % rewind 2 bytes
+        % Nsop shall be incremented no matter SOP is present or not
+    end
 end
 
 %% read packet header


### PR DESCRIPTION
SOP marker segments may not be present in the codestream even if the second LSB of the SPcod parameter is "1".